### PR TITLE
Call cudaDeviceSync before calling barrier

### DIFF
--- a/nvshmem/jacobi.cu
+++ b/nvshmem/jacobi.cu
@@ -447,11 +447,11 @@ int main(int argc, char* argv[]) {
         iter++;
     }
 
+    CUDA_RT_CALL(cudaDeviceSynchronize());
     nvshmem_barrier_all();
     double stop = MPI_Wtime();
     POP_RANGE
 
-    CUDA_RT_CALL(cudaDeviceSynchronize());
     nvshmem_barrier_all();
 
     CUDA_RT_CALL(cudaMemcpy(a_h + iy_start_global * nx, a + nx,

--- a/nvshmem_opt/jacobi.cu
+++ b/nvshmem_opt/jacobi.cu
@@ -486,11 +486,11 @@ int main(int argc, char* argv[]) {
         iter++;
     }
 
+    CUDA_RT_CALL(cudaDeviceSynchronize());
     nvshmem_barrier_all();
     double stop = MPI_Wtime();
     POP_RANGE
 
-    CUDA_RT_CALL(cudaDeviceSynchronize());
     nvshmem_barrier_all();
 
     CUDA_RT_CALL(cudaMemcpy(a_h + iy_start_global * nx, a + nx,

--- a/nvshmem_opt/jacobi.cu
+++ b/nvshmem_opt/jacobi.cu
@@ -613,7 +613,6 @@ double single_gpu(const int nx, const int ny, const int iter_max, real* const a_
             <<<dim_grid, {dim_block_x, dim_block_y, 1}, 0, compute_stream>>>(
                 a_new, a, l2_norm_d, iy_start, iy_end, nx, mype, iy_end + 1, mype, (iy_start - 1));
         CUDA_RT_CALL(cudaGetLastError());
-        nvshmemx_barrier_all_on_stream(compute_stream);
 
         if ((iter % nccheck) == 0 || (print && ((iter % 100) == 0))) {
             CUDA_RT_CALL(cudaMemcpyAsync(l2_norm_h, l2_norm_d, sizeof(real), cudaMemcpyDeviceToHost,


### PR DESCRIPTION
This is needed to ensure all work is complete before calling barrier.