### PR TITLE
Support JUWELS SLURM Setup whith one visable GPU

### DIFF
--- a/mpi/jacobi.cpp
+++ b/mpi/jacobi.cpp
@@ -140,6 +140,8 @@ int main(int argc, char* argv[]) {
     MPI_CALL(MPI_Comm_rank(MPI_COMM_WORLD, &rank));
     int size;
     MPI_CALL(MPI_Comm_size(MPI_COMM_WORLD, &size));
+    int num_devices = 0;
+    CUDA_RT_CALL(cudaGetDeviceCount(&num_devices));
 
     const int iter_max = get_argval<int>(argv, argv + argc, "-niter", 1000);
     const int nccheck = get_argval<int>(argv, argv + argc, "-nccheck", 1);
@@ -147,8 +149,9 @@ int main(int argc, char* argv[]) {
     const int ny = get_argval<int>(argv, argv + argc, "-ny", 16384);
     const bool csv = get_arg(argv, argv + argc, "-csv");
 
-    int local_rank = -1;
-    {
+    if(num_devices > 1) {
+        int local_rank = -1;
+     
         MPI_Comm local_comm;
         MPI_CALL(MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, rank, MPI_INFO_NULL,
                                      &local_comm));
@@ -156,10 +159,15 @@ int main(int argc, char* argv[]) {
         MPI_CALL(MPI_Comm_rank(local_comm, &local_rank));
 
         MPI_CALL(MPI_Comm_free(&local_comm));
+
+        CUDA_RT_CALL(cudaSetDevice(local_rank));
+        CUDA_RT_CALL(cudaFree(0));
     }
 
-    CUDA_RT_CALL(cudaSetDevice(local_rank));
-    CUDA_RT_CALL(cudaFree(0));
+    else {
+        CUDA_RT_CALL(cudaSetDevice(0));
+        CUDA_RT_CALL(cudaFree(0));
+    }
 
     real* a_ref_h;
     CUDA_RT_CALL(cudaMallocHost(&a_ref_h, nx * ny * sizeof(real)));

--- a/nvshmem_opt/jacobi.cu
+++ b/nvshmem_opt/jacobi.cu
@@ -251,32 +251,25 @@ int main(int argc, char* argv[]) {
 
     int num_devices;
     CUDA_RT_CALL(cudaGetDeviceCount(&num_devices));
-
-    int local_rank = -1, local_size = 1;
-    {
+    if(num_devices > 1) {
+        int local_rank = -1;
+     
         MPI_Comm local_comm;
-        MPI_Info info;
-        MPI_CALL(MPI_Info_create(&info));
-        MPI_CALL(
-            MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, rank, info, &local_comm));
+        MPI_CALL(MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, rank, MPI_INFO_NULL,
+                                     &local_comm));
 
         MPI_CALL(MPI_Comm_rank(local_comm, &local_rank));
-        MPI_CALL(MPI_Comm_size(local_comm, &local_size));
-        if (num_devices < local_size) {
-            fprintf(stderr,
-                    "ERROR: Number of devices is less numer of PEs \
-                    on the node!\n");
-            MPI_CALL(MPI_Comm_free(&local_comm));
-            MPI_CALL(MPI_Info_free(&info));
-            MPI_CALL(MPI_Finalize());
-            return -1;
-        }
 
         MPI_CALL(MPI_Comm_free(&local_comm));
-        MPI_CALL(MPI_Info_free(&info));
+
+        CUDA_RT_CALL(cudaSetDevice(local_rank));
+        CUDA_RT_CALL(cudaFree(0));
     }
-    CUDA_RT_CALL(cudaSetDevice(local_rank));
-    CUDA_RT_CALL(cudaFree(0));
+
+    else {
+        CUDA_RT_CALL(cudaSetDevice(0));
+        CUDA_RT_CALL(cudaFree(0));
+    }
 
     MPI_Comm mpi_comm;
     nvshmemx_init_attr_t attr;


### PR DESCRIPTION
Update the the process device assignment for systems where only one GPU is visible per process.
Required for all cases using MPI